### PR TITLE
MANPAD 2 bug fixes

### DIFF
--- a/src/main/java/me/kaiyan/missilewarfare/Items/ManPad.java
+++ b/src/main/java/me/kaiyan/missilewarfare/Items/ManPad.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class ManPad extends SlimefunItem {
     public static List<Player> active = new ArrayList<>();
-    public final int range = 300*300;
+    public final int range = 300 * 300;
 
     public ManPad(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
@@ -56,8 +56,11 @@ public class ManPad extends SlimefunItem {
                     List<MissileController> missiles = new ArrayList<>();
                     for (MissileController missile : MissileWarfare.activemissiles) {
                         if (missile.isgroundmissile) {
-                            if (missile.pos.distanceSquared(event.getPlayer().getLocation().toVector()) < range) {
-                                missiles.add(missile);
+                            // again, when checking distances, check world first!!! -Colonel_Kai
+                            if(missile.world == event.getPlayer().getWorld()) {
+                                if (missile.pos.distanceSquared(event.getPlayer().getLocation().toVector()) < range) {
+                                    missiles.add(missile);
+                                }
                             }
                         }
                     }
@@ -119,7 +122,9 @@ public class ManPad extends SlimefunItem {
 
                     // Check if sneaking
                     if (!event.getPlayer().isSneaking()) {
-                        if (lockedmissile == null){
+                        if (lockedmissile == null) {
+                            // you had forgotten to remove the player from active after it failed.
+                            active.remove(event.getPlayer());
                             event.getPlayer().sendMessage(Translations.get("messages.manpad.notarget"));
                             this.cancel();
                         } else {


### PR DESCRIPTION
1. The manpad distance check might fail upon dimension difference (same problem as before, probably should run an overall check in the future for all other distance calculations as well)
2. The MANPADs would not be able to be fired again after failing to find a target because the player was not removed from active

another question however, when I change the item in hand, it does not do `this.cancel` or remove the player from active. Any comments on why?